### PR TITLE
Bsiv2/compliance series part5 and sbomqs supports blog

### DIFF
--- a/content/posts/bsi-tr-03183-v2.1-compliance.md
+++ b/content/posts/bsi-tr-03183-v2.1-compliance.md
@@ -571,7 +571,7 @@ Love to hear your feedback https://forms.gle/anFSspwrk7uSfD7Q6
 
 The o/p gives you three clear sections:
 
-- **Required fields** (13 checks): mapped to BSI §5.2. The `sbom_spec_version` check verifies CycloneDX 1.6 or SPDX 3.0.1 minimum. The only failing check here is `comp_hash` — SHA-512 deployable hashes are still rarely populated by standard SBOM generators.
+- **Required fields** (13 checks): mapped to BSI §5.2. The `sbom_spec_version` check verifies CycloneDX 1.6 or SPDX 3.0.1 minimum. For most real-world SBOMs, `comp_hash` is the hardest required field to pass — SHA-512 deployable hashes are rarely populated by standard SBOM generators.
 - **Additional fields** (5 checks, marked `additional`): mapped to BSI §5.3. SBOM-URI, source code URI, deployable URI, unique identifiers, and original licences. Note that sbomqs uses `comp_concluded_license` as the internal check name for "original licences" — reflecting the v2.1 licence rename.
 - **Optional fields** (3 checks, marked `optional`): effective licence, source hash, and security.txt URL. These are reported as "present" rather than "compliant" since they are never a compliance violation to omit.
 
@@ -581,7 +581,7 @@ The three-tier label system (`(additional)` and `(optional)`) makes the BSI tier
 
 In this post, we discussed BSI TR-03183-2 v2.1, the August 2025 update to Germany's SBOM compliance framework and the currently required version for CRA alignment.
 
-We looked at what sets v2.1 apart from v2.0: SPDX 3.0.1 as a hard requirement (SPDX v2 is no longer accepted), CycloneDX bumped to 1.6, three explicit component roles for handling abstract products and out-of-scope dependencies, a licence terminology overhaul replacing "Associated/Concluded/Declared" with BSI's own precise terms, and two new optional fields (Effective licence and URL of security.txt).
+We looked at what sets v2.1 apart from v2.0: SPDX 3.0.1 as a hard requirement (SPDX v2 is no longer accepted), CycloneDX bumped to 1.6, three explicit component roles for handling abstract products and out-of-scope dependencies, a licence terminology overhaul (Distribution licences replaces Associated, Original licences replaces and promotes Declared, Concluded licences is removed), and two new optional fields (Effective licence and URL of security.txt).
 
 We walked through all 20 fields across all three tiers: what BSI officially requires, why each field exists, and how it maps to SPDX 3.0.1 and CycloneDX 1.6. And we saw how sbomqs evaluates your SBOM against BSI v2.1 with a single command.
 

--- a/content/posts/bsi-tr-03183-v2.1-compliance.md
+++ b/content/posts/bsi-tr-03183-v2.1-compliance.md
@@ -1,0 +1,601 @@
++++
+date = '2026-03-27T10:00:00+05:30'
+draft = false
+title = 'SBOM Compliance Series (Part 5): Understanding BSI TR-03183-2 v2.1, 🇩🇪 Germany Compliance'
+categories = ['SBOM', 'Compliance', 'BSI']
+tags = ['SBOM', 'quality', 'scoring', 'compliance', 'bsi', 'v2.1', 'germany', 'CRA']
+author = 'Vivek Sahu'
+description = 'Understand BSI TR-03183-2 v2.1, the latest Germany SBOM compliance framework. Learn its required, additional, and optional fields, what changed from v2.0, and how to validate your SBOM using sbomqs.'
++++
+
+## Overview
+
+This is the fifth part of our SBOM compliance series. In the [previous post](https://sbom-insights.dev/posts/bsi-tr-03183-v2.0-compliance/), we discussed [**BSI TR-03183-2 v2.0**](https://sbom-insights.dev/posts/bsi-tr-03183-v2.0-compliance/), what it added over v1.1, new required fields for filename, executable, archive, and structured properties, a hash algorithm upgrade to SHA-512, and a three-tier field system. In this post, we will discuss **BSI TR-03183-2 v2.1**, the latest version released in August 2025, what changed, what it now expects from an SBOM, and how to check compliance. Let's go.
+
+## Context
+
+🇩🇪 Germany's **Federal Office for Information Security (BSI)** released version **2.1.0 of TR-03183-2** on **2025-08-20**. This is the most recent and currently required version. Under BSI's transitional rule, the previous version (v2.0) may still be used for up to six months after a new version is published, meaning v2.0 expires as the accepted standard in early 2026.
+
+The motivation remains the same: the **EU Cyber Resilience Act (CRA)**. BSI TR-03183-2 is the technical guideline defining exactly what an SBOM must contain to satisfy CRA requirements for manufacturers of products with digital elements sold in the EU market. v2.1 advances this by making SPDX 3.0 a hard requirement, introducing clearer guidance on how to handle components at the boundary of your delivery scope, and tightening the licence terminology.
+
+If you've been following this series, you already have the context from v1.1 and v2.0. v2.1 builds directly on v2.0 — it is not a ground-up rewrite.
+
+## BSI's Definition of SBOM
+
+Before we look at the fields, let's understand how BSI defines an SBOM. This definition shapes every requirement that follows.
+
+BSI §3.1 defines it as:
+
+> "A 'Software Bill of Materials' (SBOM) is a machine-processable file containing supply chain relationships and details of the components used in a software product. It supports automated processing of information on these components. This covers both the so-called 'primary component' and used (e.g. external/third-party) components."
+
+A few things to understand here:
+
+**Machine-processable, not just machine-readable.** BSI is deliberate about this distinction. "Machine-processable" means tooling can create, read, modify, analyse, and act on SBOM data — not just parse it.
+
+**Supply chain relationships, not just a list.** An SBOM isn't a flat inventory. It describes relationships b/w components, including who depends on what. This underpins the recursive dependency requirement.
+
+**SBOM MUST NOT contain vulnerability information.** The SBOM is static. Vulnerability data is dynamic. Mixing them forces unnecessary SBOM regeneration every time a new CVE is published. BSI recommends CSAF or VEX for distributing vulnerability information separately.
+
+**One SBOM per software version.** A new SBOM must be generated for each software version. An updated SBOM for the same version is required only when component data is corrected or added — not for every vulnerability update.
+
+## What makes BSI v2.1 different from v2.0?
+
+If you've followed [Part 4](https://sbom-insights.dev/posts/bsi-tr-03183-v2.0-compliance/) of this series (BSI v2.0), here's what changed:
+
+**SPDX 3.0.1 is now required — SPDX v2 is no longer accepted.** This is the biggest structural change. v2.0 required SPDX 2.2.1 or higher. v2.1 requires **SPDX 3.0.1 or higher**, and SPDX v2 SBOMs are explicitly rejected. If your toolchain produces SPDX v2 output, you either need to upgrade to SPDX 3.0.1 or switch to CycloneDX 1.6. The minimum CycloneDX version is also bumped from 1.5 to **1.6**.
+
+**Three component roles introduced.** v2.0 defined every component as a single executable or archive file. That left two situations without clear guidance: how to represent an abstract product like an application made of many files, and how to handle dependencies that fall outside your delivery scope. v2.1 resolves this with three explicit component roles:
+
+- **Fully described component**: A physical file inside your scope of delivery. This is what v2.0 already required — all required fields apply, including filename, hash, and executable/archive/structured properties.
+
+- **Logical component**: An abstract representation of a product, framework, or application. No physical file. Example: a PHP application running inside a container. Because there is no deployed file, it requires no filename, hash, or property fields. It carries: creator, name, version, dependencies, distribution licences, unique identifiers, original licences, effective licence, and URL of security.txt.
+
+- **Identified component**: A physical file that exists outside your scope of delivery. You depend on it, but you didn't ship it. Only four fields are required: creator, name, version, and other unique identifiers (PURL or CPE). Just enough to let a consumer chain SBOMs unambiguously.
+
+BSI v2.1 also defines a fourth role — **referenced component** — for dependencies already described in another SBOM. You record three fields plus a pointer to that other BOM.
+
+The priority order for deciding how much detail to record (§5.1):
+
+```text
+1. Referenced component  →  3 fields + pointer to another BOM
+2. Identified component  →  4 fields (at scope boundary)
+3. Fully described component  →  all fields (inside your delivery)
+```
+
+Before v2.1, there was no guidance on what to do with components at the edge of your delivery scope. Now BSI explicitly says: identify them, don't fully describe them.
+
+**Licence terminology overhauled.** v2.0 used "Associated licences", "Concluded licences", and "Declared licences" — terms that overlap with SPDX and CycloneDX terminology in confusing ways. v2.1 replaces them with BSI's own precise terms:
+
+- **Distribution licences** (required): The licences under which the component can be used by the licensee. Maps to concluded/associated licences in SPDX/CycloneDX.
+- **Original licences** (additional): The licences assigned by the creator of the component. Maps to declared licences in SPDX/CycloneDX.
+- **Effective licence** (optional): The licence under which this specific SBOM creator is actually using the component.
+
+"Declared licences" from v2.0 is now called "Original licences" and has been promoted from optional to additional — meaning it must be included if the data exists.
+
+**New optional fields.** v2.1 adds two new optional fields that were not in v2.0 at all:
+
+- **Effective licence**: The specific licence the SBOM creator uses the component under. Distinct from what was declared upstream or concluded generally.
+- **URL of security.txt**: A link to the component creator's `security.txt` file (RFC 9116). Enables automated vulnerability reporting to the right party.
+
+**Full format mapping appendix added.** v2.1 adds §8.2, a complete field-by-field mapping table for both CycloneDX 1.6 and SPDX 3.0.1. Earlier versions had these mappings scattered across the spec. Now they are in a single appendix.
+
+Now, let's walk through each field.
+
+## Required Fields
+
+BSI §5.2 defines required fields at two levels: for the SBOM document itself, and for each component. These fields **MUST** always be present. No exceptions.
+
+### SBOM-Level Required Fields
+
+### 1. Creator of the SBOM
+
+Official definition:
+> "Email address of the entity that created the SBOM. If no email address is available this MUST be a 'Uniform Resource Locator (URL)', e.g. the creator's home page or the project's web page."
+
+Identical to v2.0. A machine-actionable contact so automated tooling can reach the responsible party without human intervention.
+
+**Accepted values**: valid email (preferred), valid URL (fallback only).
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - `SpdxDocument/creationInfo/createdBy` (Tool, Person, or Organization element, with email or URL)
+
+- CycloneDX 1.6:
+  - `metadata.authors[].email`
+  - `metadata.manufacturer.email` or `metadata.manufacturer.url`
+  - `metadata.supplier.email` or `metadata.supplier.url`
+
+> **NOTE**: Any one of these sources satisfying the email/URL requirement is sufficient.
+
+### 2. Timestamp
+
+Official definition:
+> "Date and time of the SBOM data compilation according to the specification of the formats (see section 4)"
+
+Same as v2.0. Ties the SBOM to a specific point in time for correct correlation against vulnerability databases and audit trails.
+
+**Accepted values**: RFC 3339 / ISO 8601 compliant timestamp (e.g., `2025-08-20T14:30:00Z`).
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - `SpdxDocument/creationInfo/created`
+
+- CycloneDX 1.6:
+  - `metadata.timestamp`
+
+### Component-Level Required Fields
+
+These fields apply to **fully described components** — physical files within your scope of delivery. Logical and identified components have different requirements (fewer fields), as explained in the "What makes BSI v2.1 different" section above.
+
+### 3. Component Creator
+
+Official definition:
+> "Email address of the entity that created and, if applicable, maintains the respective component. If no email address is available this MUST be a 'Uniform Resource Locator (URL)', e.g. the creator's home page or the project's web page."
+
+Same rationale as the SBOM creator, applied at the component level. If a CVE is discovered in a specific library, automated tooling must be able to identify and contact its maintainer without manual intervention.
+
+**Accepted values**: valid email (preferred), valid URL (fallback only).
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - `Package/originatedBy` (email preferred)
+  - `Package/suppliedBy` (fallback)
+
+- CycloneDX 1.6:
+  - `components[].authors[].email`
+  - `components[].manufacturer.email` or `components[].manufacturer.url`
+  - `components[].supplier.email` or `components[].supplier.url`
+
+### 4. Component Name
+
+Official definition:
+> "Name assigned to the component by its creator. If no name is assigned this MUST be the actual filename."
+
+Same as v2.0. If no name is assigned by the creator, the SBOM MUST use the actual filename.
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - `Package/name`
+
+- CycloneDX 1.6:
+  - `components[].name`
+
+### 5. Component Version
+
+Official definition:
+> "Identifier used by the creator to specify changes in the component to a previously created version. Identifiers according to Semantic Versioning or alternatively Calendar Versioning SHOULD be used if one determines the versioning scheme. If no version is assigned this MUST be the creation date of the file expressed as full-date according to RFC 3339 section 5.6."
+
+Same as v2.0. Without a version, you cannot determine whether a component is affected by a specific CVE.
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - `Package/packageVersion`
+
+- CycloneDX 1.6:
+  - `components[].version`
+
+### 6. Filename of the Component
+
+Official definition:
+> "The actual filename of the component (i.e. not its path); see also section 3.2.1"
+
+Introduced in v2.0, unchanged in v2.1. The filename of the actual file on disk — for example, `libssl.so.3` or `requests-2.31.0-py3-none-any.whl`. Path is excluded; only the filename itself.
+
+This field applies to **fully described components** only. Logical components (which have no physical file) do not need a filename.
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - `File/name` (for File elements); may also be expressed via Package when the filename is the name
+
+- CycloneDX 1.6:
+  - `components[].name` (when set to the actual filename)
+
+### 7. Dependencies on Other Components
+
+Official definition:
+> "Enumeration of all components on which this component is directly dependent, according to requirements in section 5.1, or which this component contains according to requirements in section 3.2.1."
+
+Same as v2.0. BSI requires a recursively resolved dependency graph. The primary component must declare its dependencies, and those dependencies must also be present in the SBOM. This continues recursively until you reach the delivery boundary. Components that fall outside the boundary are recorded as identified components (not fully described).
+
+> **NOTE**: Leaf components with no dependencies are compliant by declaring an empty dependency list.
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - `Relationship` with `relationshipType: dependsOn` or `contains`
+
+- CycloneDX 1.6:
+  - `dependencies[]`: `ref` (the component) and `dependsOn` (its direct dependencies)
+
+### 8. Distribution Licences (Renamed from "Associated Licences" in v2.0)
+
+Official definition:
+> "Distribution licence(s) of the component. Licence(s) under which this component can be used by the licensee; see also section 6.1."
+
+Renamed from "Associated licences" in v2.0 to "Distribution licences" in v2.1. The meaning is the same: the licences under which the component can be used by the licensee. BSI's new terminology is more precise and sidesteps the ambiguity b/w SPDX and CycloneDX licence field names.
+
+**Accepted values**: SPDX identifier (e.g., `MIT`, `Apache-2.0`), SPDX expression, or `LicenseRef-*` for non-SPDX licences. `NONE`, `NOASSERTION`, and free-text names are not accepted.
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - `Relationship` with `relationshipType: hasConcludedLicense` linking to a `LicenseExpression` element
+
+- CycloneDX 1.6:
+  - `components[].licenses[].license.id`
+  - `components[].licenses[].expression`
+
+### 9. Hash Value of the Deployable Component
+
+Official definition:
+> "Cryptographically secure checksum (hash value) of the deployed component (i.e. as a file on a mass storage device) as SHA-512; see also section 3.2.1"
+
+Unchanged from v2.0. SHA-512 hash of the delivered binary. SHA-256, SHA-1, MD5, and all other algorithms do not satisfy this requirement.
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - `Relationship` with `relationshipType: hasDistributionArtifact` pointing to a `File` element; `File/verifiedUsing` with algorithm `SHA512`
+
+- CycloneDX 1.6:
+  - `externalReferences[type=distribution or distribution-intake].hashes[]` with `alg` = `SHA-512`
+
+### 10. Executable Property
+
+Official definition:
+> "Describes whether the component is executable; possible values are 'executable' and 'non-executable'; see also section 8.1.3"
+
+Unchanged from v2.0. Executable files are files whose code is executed by a computer — compiled binaries, Python scripts, Shell scripts, Java bytecode, shared libraries. Configuration files, graphic files, and documentation are NOT executable.
+
+**Accepted values**: `executable` or `non-executable`.
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - `File/additionalPurpose` with value `executable` (for executable components)
+  - No native value for `non-executable`; may be expressed via `ExternalIdentifier` with type `OTHER`
+
+- CycloneDX 1.6:
+  - `components[].properties[]` with name `bsi:component:executable` and value `true` or `false`
+
+### 11. Archive Property
+
+Official definition:
+> "Describes whether the component is an archive; possible values are 'archive' and 'no archive'; see also section 8.1.4"
+
+Unchanged from v2.0. An archive is a combination of multiple components — `.zip`, `.tar`, `.jar`, container images. An archive can also be executable (e.g., a self-extracting binary). Compression does not change this property.
+
+**Accepted values**: `archive` or `no archive`.
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - `File/additionalPurpose` with value `archive` (for archive components)
+  - No native value for `no archive`; may be expressed via `ExternalIdentifier` with type `OTHER`
+
+- CycloneDX 1.6:
+  - `components[].properties[]` with name `bsi:component:archive` and value `true` or `false`
+
+### 12. Structured Property
+
+Official definition:
+> "Describes whether the component is a structured file, i.e. metadata of the contents is still present (see section 3.2.1); possible values are 'structured' and 'unstructured'; see also section 8.1.5. If a component contains both structured and unstructured parts the value 'structured' MUST be used."
+
+Unchanged from v2.0. A structured archive retains metadata about its original contents — containers, packages, `.zip`, `.tar`, `.tar.gz`, `.7z` are structured. A firmware image or raw binary blob is unstructured.
+
+**Accepted values**: `structured` or `unstructured`.
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - No dedicated native field. May be expressed via `ExternalIdentifier` with type `OTHER`
+
+- CycloneDX 1.6:
+  - `components[].properties[]` with name `bsi:component:structured` and value `true` or `false`
+
+## Additional Fields
+
+Additional fields **MUST be provided if they exist and their prerequisites are fulfilled** (BSI §5.3). If the data exists, omitting it is non-compliant.
+
+### SBOM-Level Additional Fields
+
+### 13. SBOM-URI
+
+Official definition:
+> "Uniform Resource Identifier (URI) of this SBOM"
+
+Unchanged from v1.1 and v2.0. A URI that uniquely identifies the SBOM document itself, enabling cross-referencing, retrieval, and linking to VEX documents or updated SBOMs.
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - `SpdxDocument/spdxId` (the SPDX 3.0.1 document's unique URI)
+
+- CycloneDX 1.6:
+  - `serialNumber` combined with `version`
+
+### Component-Level Additional Fields
+
+### 14. Source Code URI
+
+Official definition:
+> "Uniform Resource Identifier (URI) of the source code of the component, e.g. the URL of the utilised source code version in its repository, or if a version cannot be specified the utilised source code repository itself."
+
+Enables downstream consumers to audit source code, verify licence compliance, and locate patches when a vulnerability is discovered.
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - `ExternalIdentifier` with identifier type `OTHER` (no dedicated native field); or `Package/downloadLocation` pointing to source repository
+
+- CycloneDX 1.6:
+  - `components[].externalReferences[]` with type `vcs` (preferred) or `source-distribution`
+
+### 15. URI of the Deployable Form of the Component
+
+Official definition:
+> "Uniform Resource Identifier (URI) which points directly to the deployable (e.g. downloadable) form of the component."
+
+Unchanged from v2.0. Allows automated tools to retrieve the exact distributable artifact for integrity verification or deployment automation.
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - `Relationship` with `relationshipType: hasDistributionArtifact` pointing to a `Package/downloadLocation`
+
+- CycloneDX 1.6:
+  - `components[].externalReferences[]` with type `distribution` or `distribution-intake`
+
+### 16. Other Unique Identifiers
+
+Official definition:
+> "Other identifiers that can be used to identify the component or to look it up in relevant databases, such as Common Platform Enumeration (CPE) or Package URL (purl)."
+
+Unchanged from prior versions. PURL and CPE enable automated cross-referencing against vulnerability databases (NVD, OSV, GitHub Advisory Database).
+
+**Accepted values**:
+
+- **PURL** (e.g., `pkg:npm/lodash@4.17.21`)
+- **CPE** (e.g., `cpe:2.3:a:lodash:lodash:4.17.21:*:*:*:*:*:*:*`)
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - `Package/externalIdentifier` with identifier type `packageUrl` (PURL)
+  - `Package/externalIdentifier` with identifier type `cpe23Type` (CPE)
+
+- CycloneDX 1.6:
+  - `components[].purl`
+  - `components[].cpe`
+
+### 17. Original Licences (Renamed and Promoted in v2.1)
+
+Official definition:
+> "Original licence(s) of the component. Licence(s) that have been assigned to a component by the creator; see also section 6.1."
+
+This field existed in v2.0 as "Declared licences" (optional). v2.1 renames it to "Original licences" and **promotes it from optional to additional** — meaning it must now be declared if the data exists. The field captures what the original component creator declared as the licence, before any licensee's own concluded or effective licence determination.
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - `Relationship` with `relationshipType: hasDeclaredLicense` linking to a `LicenseExpression` element
+
+- CycloneDX 1.6:
+  - `components[].licenses[].license.id` (for the declared/original licence)
+
+## Optional Fields
+
+Optional fields **MAY** be included if the data exists. Even if the data is available, omitting optional fields is not a compliance violation. v2.1 has three optional fields: one carried over from v2.0 and two newly added.
+
+### Component-Level Optional Fields
+
+### 18. Effective Licence (New in v2.1)
+
+Official definition:
+> "Effective licence(s) of the component. Licence(s) under which the SBOM creator uses this component; see also section 6.1."
+
+New in v2.1. Where distribution licences represent what the component can be used under, and original licences represent what the creator declared — effective licence is the specific licence this SBOM creator has actually chosen to use the component under. It is relevant when a component is available under multiple licences (e.g., Apache-2.0 OR MIT) and the SBOM creator wants to declare which one they are using.
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - Custom `Relationship` with `relationshipType: other` and a `comment` field indicating `hasEffectiveLicense`
+
+- CycloneDX 1.6:
+  - `components[].properties[]` with name `bsi:component:effectiveLicense`
+
+### 19. Hash Value of Source Code
+
+Official definition:
+> "Cryptographically secure checksum (hash value) of the component source code. A specific algorithm how to create a hash value of multiple source files or a source code tree, and which hash algorithm is utilised for that has not yet been determined."
+
+Carried over from v2.0 (where it was also optional). Together with the deployable component hash (field 9), this establishes a verifiable chain from source to binary. BSI has not yet standardised the algorithm for hashing a multi-file source tree — until that is resolved, it cannot be a mandatory data point.
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - `Package/verifiedUsing` on a source Package element (closest available field)
+
+- CycloneDX 1.6:
+  - `components[].externalReferences[]` with type `vcs` or `source-distribution`, including associated `hashes[]`
+
+### 20. URL of Security.txt (New in v2.1)
+
+Official definition:
+> "URL of the security.txt file of the component creator (see RFC 9116)."
+
+New in v2.1. `security.txt` (RFC 9116) is a standard that allows organisations to define a contact for security vulnerability reporting. Including this URL in the SBOM means that automated tooling — or a security researcher who finds a vulnerability in this component — can immediately find the right channel to report it. This closes the loop on the "who do I contact?" problem at the component level.
+
+**SBOM Mapping**:
+
+- SPDX 3.0.1:
+  - `ExternalIdentifier` with identifier type `OTHER` pointing to the `security.txt` URL
+
+- CycloneDX 1.6:
+  - `components[].externalReferences[]` with type `security-contact` pointing to the `security.txt` URL
+
+## Field Summary Table
+
+| # | Field | Level | Category | BSI Section |
+|---|-------|-------|----------|-------------|
+| 1 | Creator of the SBOM | SBOM | Required | §5.2.1 |
+| 2 | Timestamp | SBOM | Required | §5.2.1 |
+| 3 | Component creator | Component | Required | §5.2.2 |
+| 4 | Component name | Component | Required | §5.2.2 |
+| 5 | Component version | Component | Required | §5.2.2 |
+| 6 | Filename of the component | Component | Required | §5.2.2 |
+| 7 | Dependencies on other components | Component | Required | §5.2.2 |
+| 8 | Distribution licences | Component | Required | §5.2.2 |
+| 9 | Hash value of the deployable component | Component | Required | §5.2.2 |
+| 10 | Executable property | Component | Required | §5.2.2 |
+| 11 | Archive property | Component | Required | §5.2.2 |
+| 12 | Structured property | Component | Required | §5.2.2 |
+| 13 | SBOM-URI | SBOM | Additional | §5.3.1 |
+| 14 | Source code URI | Component | Additional | §5.3.2 |
+| 15 | URI of the deployable form | Component | Additional | §5.3.2 |
+| 16 | Other unique identifiers | Component | Additional | §5.3.2 |
+| 17 | Original licences | Component | Additional | §5.3.2 |
+| 18 | Effective licence | Component | Optional | §5.4.1 |
+| 19 | Hash value of source code | Component | Optional | §5.4.1 |
+| 20 | URL of security.txt | Component | Optional | §5.4.1 |
+
+**v2.0 had 19 fields. v2.1 has 20.** The core required fields remain 12. The main changes are in the licence tier: "Original licences" moves from optional to additional, and two new optional fields are added (Effective licence + security.txt URL).
+
+## How to evaluate your SBOM against BSI TR-03183-2 v2.1
+
+At this point, we've walked through all 20 fields. The next natural question is:
+
+> How do you actually check whether your SBOM meets BSI v2.1 requirements?
+
+This is where [sbomqs](https://github.com/interlynk-io/sbomqs) comes in.
+
+**sbomqs** is an open-source CLI tool that evaluates SBOMs after they are generated. It checks both SBOM quality and compliance against standard frameworks, including BSI TR-03183-2 v2.1.
+
+> For details on how sbomqs added v2.1 support, what changed, and how the `bsi` alias now points to v2.1, see our post on [sbomqs BSI v2.1 support](/posts/sbomqs-bsi-v2.1-compliance-support/).
+
+Run a single command to score your SBOM against BSI v2.1:
+
+```bash
+sbomqs score --profile bsi-v2.1 your-sbom.cdx.json
+```
+
+And the o/p looks like this:
+
+```bash
+SBOM Quality Score: 10.0/10.0	 Grade: A	Components: 2 	 EngineVersion: 6	File: testdata/bsi/cdx/validFullyCompliantBsiV21.cdx16.json
+
+
++---------------------+---------------------------+------------------------+--------------------------------+
+|       PROFILE       |          FEATURE          |         STATUS         |              DESC              |
++---------------------+---------------------------+------------------------+--------------------------------+
+| BSI TR-03183-2 v2.1 | sbom_spec_version         | 10.0/10.0              | CycloneDX 1.6 meets minimum    |
+|                     |                           |                        | version 1.6                    |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | sbom_creator              | 10.0/10.0              | SBOM creator contact(email)    |
+|                     |                           |                        | provided via authors           |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | sbom_timestamp            | 10.0/10.0              | SBOM creation timestamp is     |
+|                     |                           |                        | valid and RFC3339-compliant.   |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_creator              | 10.0/10.0              | creator contact (email or URL) |
+|                     |                           |                        | declared for all components    |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_name                 | 10.0/10.0              | component name declared for    |
+|                     |                           |                        | all components                 |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_version              | 10.0/10.0              | component version declared for |
+|                     |                           |                        | all components                 |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_filename             | 10.0/10.0              | filename declared for all      |
+|                     |                           |                        | components                     |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_depth                | 10.0/10.0              | Dependencies are recursively   |
+|                     |                           |                        | declared and structurally      |
+|                     |                           |                        | complete.                      |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_distribution_license | 10.0/10.0              | distribution licence           |
+|                     |                           |                        | (concluded) declared for all   |
+|                     |                           |                        | components                     |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_hash                 | 10.0/10.0              | deployable component hash      |
+|                     |                           |                        | declared for all components    |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_executable_prop      | 10.0/10.0              | executable property declared   |
+|                     |                           |                        | for all components             |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_archive_prop         | 10.0/10.0              | archive property declared for  |
+|                     |                           |                        | all components                 |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_structured_prop      | 10.0/10.0              | structured property declared   |
+|                     |                           |                        | for all components             |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | sbom_uri                  | 10.0/10.0 (additional) | SBOM-URI is declared           |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_source_code_url      | 10.0/10.0 (additional) | source code URI declared for   |
+|                     |                           |                        | all components                 |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_download_url         | 10.0/10.0 (additional) | deployable form URI declared   |
+|                     |                           |                        | for all components             |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_other_identifiers    | 10.0/10.0 (additional) | unique identifiers             |
+|                     |                           |                        | (CPE/SWID/purl) declared for   |
+|                     |                           |                        | all components                 |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_original_licenses    | 10.0/10.0 (additional) | original licence (declared)    |
+|                     |                           |                        | declared for all components    |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_effective_license    | 10.0/10.0 (optional)   | effective licence declared for |
+|                     |                           |                        | all components                 |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_source_hash          | 10.0/10.0 (optional)   | source code hash declared for  |
+|                     |                           |                        | all components                 |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_security_txt_url     | 10.0/10.0 (optional)   | security.txt URL declared for  |
+|                     |                           |                        | all components                 |
++---------------------+---------------------------+------------------------+--------------------------------+
+
+
+Summary:
+Required Fields   : 13/13 compliant
+Additional Fields : 5/5 compliant
+Optional Fields   : 3/3 present
+
+Love to hear your feedback https://forms.gle/anFSspwrk7uSfD7Q6
+```
+
+The o/p gives you three clear sections:
+
+- **Required fields** (13 checks): mapped to BSI §5.2. The `sbom_spec_version` check verifies CycloneDX 1.6 or SPDX 3.0.1 minimum. The only failing check here is `comp_hash` — SHA-512 deployable hashes are still rarely populated by standard SBOM generators.
+- **Additional fields** (5 checks, marked `additional`): mapped to BSI §5.3. SBOM-URI, source code URI, deployable URI, unique identifiers, and original licences. Note that sbomqs uses `comp_concluded_license` as the internal check name for "original licences" — reflecting the v2.1 licence rename.
+- **Optional fields** (3 checks, marked `optional`): effective licence, source hash, and security.txt URL. These are reported as "present" rather than "compliant" since they are never a compliance violation to omit.
+
+The three-tier label system (`(additional)` and `(optional)`) makes the BSI tiers immediately distinguishable in the output. For most real-world SBOMs, the biggest gaps will be in deployable hash (SHA-512 is rarely populated) and the additional fields — especially source code URI and deployable form URI.
+
+## Conclusion and what's next
+
+In this post, we discussed BSI TR-03183-2 v2.1, the August 2025 update to Germany's SBOM compliance framework and the currently required version for CRA alignment.
+
+We looked at what sets v2.1 apart from v2.0: SPDX 3.0.1 as a hard requirement (SPDX v2 is no longer accepted), CycloneDX bumped to 1.6, three explicit component roles for handling abstract products and out-of-scope dependencies, a licence terminology overhaul replacing "Associated/Concluded/Declared" with BSI's own precise terms, and two new optional fields (Effective licence and URL of security.txt).
+
+We walked through all 20 fields across all three tiers: what BSI officially requires, why each field exists, and how it maps to SPDX 3.0.1 and CycloneDX 1.6. And we saw how sbomqs evaluates your SBOM against BSI v2.1 with a single command.
+
+If you are building software products targeting the EU market, BSI v2.1 is the version to align with today. The 6-month transitional window after each new version means the clock starts ticking from the day it is published.
+
+In the next post of this series, we'll look at **OpenChain Telco SBOM Guide**, the SBOM standard from the OpenChain project aimed at the telecommunications and high-availability software supply chains.
+
+## Resources
+
+- [BSI TR-03183-2 v2.1.0 Official Document](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TR03183/BSI-TR-03183-2_v2_1_0.pdf)
+- [BSI TR-03183 Overview](https://www.bsi.bund.de/dok/TR-03183-en)
+- [sbomqs BSI v2.1 Scoring Support](/posts/sbomqs-bsi-v2.1-compliance-support/)
+- [sbomqs GitHub](https://github.com/interlynk-io/sbomqs)
+- [Part 1: NTIA Minimum Elements](https://sbom-insights.dev/posts/ntia-minimum-elements-2021-compliance/)
+- [Part 2: FSCT](https://sbom-insights.dev/posts/fsct/)
+- [Part 3: BSI TR-03183-2 v1.1](https://sbom-insights.dev/posts/bsi-tr-03183-v1.1-compliance/)
+- [Part 4: BSI TR-03183-2 v2.0](https://sbom-insights.dev/posts/bsi-tr-03183-v2.0-compliance/)

--- a/content/posts/bsi-tr-03183-v2.1-compliance.md
+++ b/content/posts/bsi-tr-03183-v2.1-compliance.md
@@ -16,9 +16,9 @@ This is the fifth part of our SBOM compliance series. In the [previous post](htt
 
 🇩🇪 Germany's **Federal Office for Information Security (BSI)** released version **2.1.0 of TR-03183-2** on **2025-08-20**. This is the most recent and currently required version. Under BSI's transitional rule, the previous version (v2.0) may still be used for up to six months after a new version is published, meaning v2.0 expires as the accepted standard in early 2026.
 
-The motivation remains the same: the **EU Cyber Resilience Act (CRA)**. BSI TR-03183-2 is the technical guideline defining exactly what an SBOM must contain to satisfy CRA requirements for manufacturers of products with digital elements sold in the EU market. v2.1 advances this by making SPDX 3.0 a hard requirement, introducing clearer guidance on how to handle components at the boundary of your delivery scope, and tightening the licence terminology.
+The motivation remains the same: the **EU Cyber Resilience Act (CRA)**. BSI TR-03183-2 is the technical guideline defining exactly what an SBOM must contain to satisfy CRA requirements for manufacturers of products with digital elements sold in the EU market. v2.1 advances this by making SPDX 3.0.1 a hard requirement, introducing clearer guidance on how to handle components at the boundary of your delivery scope, and tightening the licence terminology.
 
-If you've been following this series, you already have the context from v1.1 and v2.0. v2.1 builds directly on v2.0 — it is not a ground-up rewrite.
+If you've been following this series, you already have the context from v1.1 and v2.0. v2.1 builds directly on v2.0, it is not a ground-up rewrite.
 
 ## BSI's Definition of SBOM
 
@@ -30,47 +30,39 @@ BSI §3.1 defines it as:
 
 A few things to understand here:
 
-**Machine-processable, not just machine-readable.** BSI is deliberate about this distinction. "Machine-processable" means tooling can create, read, modify, analyse, and act on SBOM data — not just parse it.
+**Machine-processable, not just machine-readable.** BSI is deliberate about this distinction. "Machine-processable" means tooling can create, read, modify, analyse, and act on SBOM data, not just parse it.
 
 **Supply chain relationships, not just a list.** An SBOM isn't a flat inventory. It describes relationships b/w components, including who depends on what. This underpins the recursive dependency requirement.
 
 **SBOM MUST NOT contain vulnerability information.** The SBOM is static. Vulnerability data is dynamic. Mixing them forces unnecessary SBOM regeneration every time a new CVE is published. BSI recommends CSAF or VEX for distributing vulnerability information separately.
 
-**One SBOM per software version.** A new SBOM must be generated for each software version. An updated SBOM for the same version is required only when component data is corrected or added — not for every vulnerability update.
+**One SBOM per software version.** A new SBOM must be generated for each software version. An updated SBOM for the same version is required only when component data is corrected or added, not for every vulnerability update.
 
 ## What makes BSI v2.1 different from v2.0?
 
 If you've followed [Part 4](https://sbom-insights.dev/posts/bsi-tr-03183-v2.0-compliance/) of this series (BSI v2.0), here's what changed:
 
-**SPDX 3.0.1 is now required — SPDX v2 is no longer accepted.** This is the biggest structural change. v2.0 required SPDX 2.2.1 or higher. v2.1 requires **SPDX 3.0.1 or higher**, and SPDX v2 SBOMs are explicitly rejected. If your toolchain produces SPDX v2 output, you either need to upgrade to SPDX 3.0.1 or switch to CycloneDX 1.6. The minimum CycloneDX version is also bumped from 1.5 to **1.6**.
+**SPDX 3.0.1 is now required, SPDX v2 is no longer accepted.** This is the biggest structural change. v2.0 required SPDX 2.2.1 or higher. v2.1 requires **SPDX 3.0.1 or higher**. If your toolchain produces SPDX v2 output, you either need to upgrade to SPDX 3.0.1 or switch to CycloneDX 1.6. The minimum CycloneDX version is also bumped from 1.5 to **1.6**.
 
 **Three component roles introduced.** v2.0 defined every component as a single executable or archive file. That left two situations without clear guidance: how to represent an abstract product like an application made of many files, and how to handle dependencies that fall outside your delivery scope. v2.1 resolves this with three explicit component roles:
 
-- **Fully described component**: A physical file inside your scope of delivery. This is what v2.0 already required — all required fields apply, including filename, hash, and executable/archive/structured properties.
+- **Fully described component**: A physical file inside your scope of delivery. This is what v2.0 already required, all required fields apply, including filename, hash, and executable/archive/structured properties.
 
 - **Logical component**: An abstract representation of a product, framework, or application. No physical file. Example: a PHP application running inside a container. Because there is no deployed file, it requires no filename, hash, or property fields. It carries: creator, name, version, dependencies, distribution licences, unique identifiers, original licences, effective licence, and URL of security.txt.
 
 - **Identified component**: A physical file that exists outside your scope of delivery. You depend on it, but you didn't ship it. Only four fields are required: creator, name, version, and other unique identifiers (PURL or CPE). Just enough to let a consumer chain SBOMs unambiguously.
 
-BSI v2.1 also defines a fourth role — **referenced component** — for dependencies already described in another SBOM. You record three fields plus a pointer to that other BOM.
-
-The priority order for deciding how much detail to record (§5.1):
-
-```text
-1. Referenced component  →  3 fields + pointer to another BOM
-2. Identified component  →  4 fields (at scope boundary)
-3. Fully described component  →  all fields (inside your delivery)
-```
+BSI v2.1 also defines a fourth role, **referenced component**, for dependencies already described in another SBOM. You record three fields plus a pointer to that other BOM.
 
 Before v2.1, there was no guidance on what to do with components at the edge of your delivery scope. Now BSI explicitly says: identify them, don't fully describe them.
 
-**Licence terminology overhauled.** v2.0 used "Associated licences", "Concluded licences", and "Declared licences" — terms that overlap with SPDX and CycloneDX terminology in confusing ways. v2.1 replaces them with BSI's own precise terms:
+**Licence terminology overhauled.** v2.0 used "Associated licences", "Concluded licences", and "Declared licences", terms that overlap with SPDX and CycloneDX terminology in confusing ways. v2.1 replaces them with BSI's own precise terms:
 
 - **Distribution licences** (required): The licences under which the component can be used by the licensee. Maps to concluded/associated licences in SPDX/CycloneDX.
 - **Original licences** (additional): The licences assigned by the creator of the component. Maps to declared licences in SPDX/CycloneDX.
 - **Effective licence** (optional): The licence under which this specific SBOM creator is actually using the component.
 
-"Declared licences" from v2.0 is now called "Original licences" and has been promoted from optional to additional — meaning it must be included if the data exists.
+"Declared licences" from v2.0 is now called "Original licences" and has been promoted from optional to additional, meaning it must be included if the data exists.
 
 **New optional fields.** v2.1 adds two new optional fields that were not in v2.0 at all:
 
@@ -113,7 +105,7 @@ Identical to v2.0. A machine-actionable contact so automated tooling can reach t
 Official definition:
 > "Date and time of the SBOM data compilation according to the specification of the formats (see section 4)"
 
-Same as v2.0. Ties the SBOM to a specific point in time for correct correlation against vulnerability databases and audit trails.
+Same as v2.0.
 
 **Accepted values**: RFC 3339 / ISO 8601 compliant timestamp (e.g., `2025-08-20T14:30:00Z`).
 
@@ -127,14 +119,14 @@ Same as v2.0. Ties the SBOM to a specific point in time for correct correlation 
 
 ### Component-Level Required Fields
 
-These fields apply to **fully described components** — physical files within your scope of delivery. Logical and identified components have different requirements (fewer fields), as explained in the "What makes BSI v2.1 different" section above.
+These fields apply to **fully described components**, physical files within your scope of delivery. Logical and identified components have different requirements (fewer fields), as explained in the "What makes BSI v2.1 different" section above.
 
 ### 3. Component Creator
 
 Official definition:
 > "Email address of the entity that created and, if applicable, maintains the respective component. If no email address is available this MUST be a 'Uniform Resource Locator (URL)', e.g. the creator's home page or the project's web page."
 
-Same rationale as the SBOM creator, applied at the component level. If a CVE is discovered in a specific library, automated tooling must be able to identify and contact its maintainer without manual intervention.
+Same rationale as the SBOM creator, applied at the component level. If a CVE is found in a library, automated tooling needs to contact that library's maintainer, not a human intermediary.
 
 **Accepted values**: valid email (preferred), valid URL (fallback only).
 
@@ -184,7 +176,7 @@ Same as v2.0. Without a version, you cannot determine whether a component is aff
 Official definition:
 > "The actual filename of the component (i.e. not its path); see also section 3.2.1"
 
-Introduced in v2.0, unchanged in v2.1. The filename of the actual file on disk — for example, `libssl.so.3` or `requests-2.31.0-py3-none-any.whl`. Path is excluded; only the filename itself.
+Introduced in v2.0, unchanged in v2.1. The filename of the actual file on disk, for example, `libssl.so.3` or `requests-2.31.0-py3-none-any.whl`. Path is excluded; only the filename itself.
 
 This field applies to **fully described components** only. Logical components (which have no physical file) do not need a filename.
 
@@ -251,7 +243,7 @@ Unchanged from v2.0. SHA-512 hash of the delivered binary. SHA-256, SHA-1, MD5, 
 Official definition:
 > "Describes whether the component is executable; possible values are 'executable' and 'non-executable'; see also section 8.1.3"
 
-Unchanged from v2.0. Executable files are files whose code is executed by a computer — compiled binaries, Python scripts, Shell scripts, Java bytecode, shared libraries. Configuration files, graphic files, and documentation are NOT executable.
+Unchanged from v2.0. Executable files are files whose code is executed by a computer, compiled binaries, Python scripts, Shell scripts, Java bytecode, shared libraries. Configuration files, graphic files, and documentation are NOT executable.
 
 **Accepted values**: `executable` or `non-executable`.
 
@@ -269,7 +261,7 @@ Unchanged from v2.0. Executable files are files whose code is executed by a comp
 Official definition:
 > "Describes whether the component is an archive; possible values are 'archive' and 'no archive'; see also section 8.1.4"
 
-Unchanged from v2.0. An archive is a combination of multiple components — `.zip`, `.tar`, `.jar`, container images. An archive can also be executable (e.g., a self-extracting binary). Compression does not change this property.
+Unchanged from v2.0. An archive is a combination of multiple components, `.zip`, `.tar`, `.jar`, container images. An archive can also be executable (e.g., a self-extracting binary). Compression does not change this property.
 
 **Accepted values**: `archive` or `no archive`.
 
@@ -287,7 +279,7 @@ Unchanged from v2.0. An archive is a combination of multiple components — `.zi
 Official definition:
 > "Describes whether the component is a structured file, i.e. metadata of the contents is still present (see section 3.2.1); possible values are 'structured' and 'unstructured'; see also section 8.1.5. If a component contains both structured and unstructured parts the value 'structured' MUST be used."
 
-Unchanged from v2.0. A structured archive retains metadata about its original contents — containers, packages, `.zip`, `.tar`, `.tar.gz`, `.7z` are structured. A firmware image or raw binary blob is unstructured.
+Unchanged from v2.0. A structured archive retains metadata about its original contents, containers, packages, `.zip`, `.tar`, `.tar.gz`, `.7z` are structured. A firmware image or raw binary blob is unstructured.
 
 **Accepted values**: `structured` or `unstructured`.
 
@@ -379,7 +371,7 @@ Unchanged from prior versions. PURL and CPE enable automated cross-referencing a
 Official definition:
 > "Original licence(s) of the component. Licence(s) that have been assigned to a component by the creator; see also section 6.1."
 
-This field existed in v2.0 as "Declared licences" (optional). v2.1 renames it to "Original licences" and **promotes it from optional to additional** — meaning it must now be declared if the data exists. The field captures what the original component creator declared as the licence, before any licensee's own concluded or effective licence determination.
+This field existed in v2.0 as "Declared licences" (optional). v2.1 renames it to "Original licences" and **promotes it from optional to additional**, meaning it must now be declared if the data exists. The field captures what the original component creator declared as the licence, before any licensee's own concluded or effective licence determination.
 
 **SBOM Mapping**:
 
@@ -400,7 +392,7 @@ Optional fields **MAY** be included if the data exists. Even if the data is avai
 Official definition:
 > "Effective licence(s) of the component. Licence(s) under which the SBOM creator uses this component; see also section 6.1."
 
-New in v2.1. Where distribution licences represent what the component can be used under, and original licences represent what the creator declared — effective licence is the specific licence this SBOM creator has actually chosen to use the component under. It is relevant when a component is available under multiple licences (e.g., Apache-2.0 OR MIT) and the SBOM creator wants to declare which one they are using.
+New in v2.1. Where distribution licences represent what the component can be used under, and original licences represent what the creator declared, effective licence is the specific licence this SBOM creator has actually chosen to use the component under. It is relevant when a component is available under multiple licences (e.g., Apache-2.0 OR MIT) and the SBOM creator wants to declare which one they are using.
 
 **SBOM Mapping**:
 
@@ -415,7 +407,7 @@ New in v2.1. Where distribution licences represent what the component can be use
 Official definition:
 > "Cryptographically secure checksum (hash value) of the component source code. A specific algorithm how to create a hash value of multiple source files or a source code tree, and which hash algorithm is utilised for that has not yet been determined."
 
-Carried over from v2.0 (where it was also optional). Together with the deployable component hash (field 9), this establishes a verifiable chain from source to binary. BSI has not yet standardised the algorithm for hashing a multi-file source tree — until that is resolved, it cannot be a mandatory data point.
+Carried over from v2.0 (where it was also optional). Together with the deployable component hash (field 9), this establishes a verifiable chain from source to binary. BSI has not yet standardised the algorithm for hashing a multi-file source tree, until that is resolved, it cannot be a mandatory data point.
 
 **SBOM Mapping**:
 
@@ -430,7 +422,7 @@ Carried over from v2.0 (where it was also optional). Together with the deployabl
 Official definition:
 > "URL of the security.txt file of the component creator (see RFC 9116)."
 
-New in v2.1. `security.txt` (RFC 9116) is a standard that allows organisations to define a contact for security vulnerability reporting. Including this URL in the SBOM means that automated tooling — or a security researcher who finds a vulnerability in this component — can immediately find the right channel to report it. This closes the loop on the "who do I contact?" problem at the component level.
+New in v2.1. `security.txt` (RFC 9116) is a standard that allows organisations to define a contact for security vulnerability reporting. Including this URL in the SBOM means that automated tooling, or a security researcher who finds a vulnerability in this component, can immediately find the right channel to report it. This closes the loop on the "who do I contact?" problem at the component level.
 
 **SBOM Mapping**:
 
@@ -482,7 +474,7 @@ This is where [sbomqs](https://github.com/interlynk-io/sbomqs) comes in.
 Run a single command to score your SBOM against BSI v2.1:
 
 ```bash
-sbomqs score --profile bsi-v2.1 your-sbom.cdx.json
+sbomqs score --profile bsi-v2.1 testdata/bsi/cdx/validFullyCompliantBsiV21.cdx16.json
 ```
 
 And the o/p looks like this:
@@ -571,11 +563,11 @@ Love to hear your feedback https://forms.gle/anFSspwrk7uSfD7Q6
 
 The o/p gives you three clear sections:
 
-- **Required fields** (13 checks): mapped to BSI §5.2. The `sbom_spec_version` check verifies CycloneDX 1.6 or SPDX 3.0.1 minimum. For most real-world SBOMs, `comp_hash` is the hardest required field to pass — SHA-512 deployable hashes are rarely populated by standard SBOM generators.
-- **Additional fields** (5 checks, marked `additional`): mapped to BSI §5.3. SBOM-URI, source code URI, deployable URI, unique identifiers, and original licences. Note that sbomqs uses `comp_concluded_license` as the internal check name for "original licences" — reflecting the v2.1 licence rename.
+- **Required fields** (13 checks): mapped to BSI §5.2. The `sbom_spec_version` check verifies CycloneDX 1.6 or SPDX 3.0.1 minimum. For most real-world SBOMs, `comp_hash` is the hardest required field to pass, SHA-512 deployable hashes are rarely populated by standard SBOM generators.
+- **Additional fields** (5 checks, marked `additional`): mapped to BSI §5.3. SBOM-URI, source code URI, deployable URI, unique identifiers, and original licences. Note that sbomqs uses `comp_concluded_license` as the internal check name for "original licences", reflecting the v2.1 licence rename.
 - **Optional fields** (3 checks, marked `optional`): effective licence, source hash, and security.txt URL. These are reported as "present" rather than "compliant" since they are never a compliance violation to omit.
 
-The three-tier label system (`(additional)` and `(optional)`) makes the BSI tiers immediately distinguishable in the output. For most real-world SBOMs, the biggest gaps will be in deployable hash (SHA-512 is rarely populated) and the additional fields — especially source code URI and deployable form URI.
+The three-tier label system (`(additional)` and `(optional)`) makes the BSI tiers immediately distinguishable in the output. For most real-world SBOMs, the biggest gaps will be in deployable hash (SHA-512 is rarely populated) and the additional fields, especially source code URI and deployable form URI.
 
 ## Conclusion and what's next
 

--- a/content/posts/sbomqs-bsi-v2.1-compliance-support.md
+++ b/content/posts/sbomqs-bsi-v2.1-compliance-support.md
@@ -1,7 +1,7 @@
 +++
 date = '2026-03-27T10:00:00+05:30'
 draft = false
-title = 'sbomqs Now Supports BSI TR-03183 v2.1: What Changed and How to Score Your SBOM'
+title = 'sbomqs now supports BSI TR-03183 v2.1: What changed and how to score your SBOM'
 categories = ['Compliance', 'Quality', 'Tools']
 tags = ['SBOM', 'sbomqs', 'BSI', 'Compliance', 'CRA', 'Standards', 'Security', 'SBOM Quality']
 author = 'Vivek Sahu'
@@ -10,13 +10,13 @@ description = 'sbomqs now supports BSI TR-03183-2 v2.1 compliance scoring. Learn
 
 Hey SBOM community,
 
-Good news — [sbomqs](https://github.com/interlynk-io/sbomqs) now supports **BSI TR-03183-2 v2.1** compliance scoring.
+Good news, [sbomqs](https://github.com/interlynk-io/sbomqs) now supports **BSI TR-03183-2 v2.1** compliance scoring.
 
-If you've been following BSI compliance, you already know: BSI doesn't sit still. It has been one of the most consistently evolving SBOM compliance frameworks out there. Since its first publication in 2023, BSI has released a new version roughly every year — and each version has brought real, meaningful improvements to how SBOMs are expected to be structured.
+If you've been following BSI compliance, you already know: BSI doesn't sit still. It has been one of the most consistent SBOM compliance frameworks that kept on evolving. Since its first publication in 2023, BSI has released a new version roughly every year, and each version has brought real, meaningful improvements to how SBOMs are expected to be structured.
 
-We already supported BSI v1.1 and BSI v2.0 in sbomqs. Now, with v2.1 being the most recent and the one that must be used for compliance, we've added full scoring support for it too.
+We already support BSI v1.1 and BSI v2.0 in sbomqs for both SPDX and CycloneDX. Now, with v2.1 being the most recent and the one that must be used for compliance, we've added full scoring support for CycloneDX spec SBOM only. Currently we don't support SPDX:3.0.1 which is required format for bsi:v2.1.
 
-> If you want a deep dive into every BSI v2.1 field — what it means, what it maps to in SPDX and CycloneDX — check out our compliance series blog on BSI v2.1. This post focuses on what changed and how to use sbomqs to score your SBOM against it.
+> If you want a deep dive into every BSI v2.1 field what it means, what it maps to in SPDX and CycloneDX, check out our compliance series blog on [BSI v2.1](https://sbom-insights.dev/posts/bsi-tr-03183-v2.1-compliance/). This post focuses on what changed and how to use sbomqs to score your SBOM against it.
 
 ## What is BSI TR-03183?
 
@@ -24,7 +24,7 @@ We already supported BSI v1.1 and BSI v2.0 in sbomqs. Now, with v2.1 being the m
 
 The reason BSI matters so much right now is the **EU Cyber Resilience Act (CRA)**. The CRA requires manufacturers of products with digital components to continuously handle vulnerabilities and provide transparent information about their products. BSI TR-03183 is closely aligned with CRA requirements, making it the go-to SBOM standard for organizations selling software products in the European market.
 
-> If you're selling software in Europe, BSI compliance is increasingly becoming a requirement — not a nice-to-have.
+> If you're selling software in Europe, BSI compliance is increasingly becoming a requirement, not a nice-to-have.
 
 ## BSI Version History
 
@@ -41,16 +41,14 @@ So BSI v2.1 is now the required version. Let's look at what changed.
 
 ## What Changed from BSI v2.0 to BSI v2.1?
 
-BSI v2.1 is not a ground-up rewrite. But there are several meaningful changes that affect both how you write your SBOM and how sbomqs scores it.
-
-### 1. Format Version Bumps — and SPDX v2 is No Longer Allowed
+### 1. Format version bumps and SPDX v2 is no longer allowed
 
 | Format     | BSI v2.0 Minimum | BSI v2.1 Minimum |
 | ---------- | ---------------- | ---------------- |
 | CycloneDX  | 1.5              | **1.6**          |
 | SPDX       | 2.2.1            | **3.0.1**        |
 
-The SPDX change is the bigger one. BSI v2.1 requires SPDX 3.0.1 or higher — SPDX v2 is no longer accepted. In sbomqs, if you score an SPDX v2 SBOM against the `bsi-v2.1` profile, it gets a **hard fail** on the format version check and all individual field checks return N/A.
+The SPDX change is the bigger one. BSI v2.1 requires SPDX 3.0.1 or higher. sbomqs does not yet support SPDX 3.0.1, so if you score an SPDX v2 SBOM against `bsi-v2.1`, sbomqs does not hard fail it, instead it performs a best-effort check against the fields that SPDX v2 does support. Fields that BSI v2.1 expects but don't exist in SPDX v2 will simply not be checkable. If you want accurate SPDX v2 scoring against BSI, use the `bsi-v1.1` profile, it is built specifically for SPDX v2. Or use `bsi-v2.0`, which is very close to v2.1 in field requirements and supports SPDX v2 field mappings for BSI v2.0 fields.
 
 ### 2. New Component Concepts Introduced
 
@@ -58,16 +56,16 @@ Before v2.1, BSI defined every component as a single executable or archive file.
 
 v2.1 solves this by introducing two new component roles alongside the existing fully described component:
 
-**Logical Component**: An abstract representation of a product, framework, or application — not a physical file. For example: a PHP application running inside a container. Without a logical component, your SBOM is just a pile of files with no concept of "this is my app." A logical component names that unit and can carry a BOM reference pointing to its own SBOM. Because there is no physical file, it requires no filename, hash, or executable/archive/structured properties — just creator, name, version, dependencies, licence fields, unique identifiers, and URL of **security.txt**.
+**Logical Component**: An abstract representation of a product, framework, or application, not a physical file. For example: a PHP application running inside a container. Without a logical component, your SBOM is just a pile of files with no concept of "this is my app." A logical component names that unit and can carry a BOM reference pointing to its own SBOM. Because there is no physical file, it requires no filename, hash, or executable/archive/structured properties, just creator, name, version, dependencies, licence fields, unique identifiers, and URL of **security.txt**.
 
-**Identified Component**: A physical file that exists *outside* your scope of delivery — something your software depends on but you didn't ship. You don't need to fully describe it, just identify it so consumers can unambiguously chain SBOMs. Minimum fields: creator, name, version, and other unique identifiers (PURL or CPE).
+**Identified Component**: A physical file that exists *outside* your scope of delivery, something your software depends on but you didn't ship. You don't need to fully describe it, just identify it so consumers can unambiguously chain SBOMs. Minimum fields: creator, name, version, and other unique identifiers (PURL or CPE).
 
 BSI v2.1 gives a clear priority order for deciding how much to record:
 
-```
-1. Referenced component  →  3 fields + pointer to another BOM
-2. Identified component  →  4 fields (at scope boundary)
-3. Fully described component  →  all fields (inside your delivery)
+```text
+1. Referenced component: 3 fields + pointer to another BOM
+2. Identified component: 4 fields (at scope boundary)
+3. Fully described component: all fields (inside your delivery)
 ```
 
 Before v2.1, there was no guidance on how to handle components at the boundary of your delivery. Now BSI explicitly tells you: identify them, don't fully describe them.
@@ -84,7 +82,7 @@ The reason for this: the terms "declared" and "concluded" are used differently a
 
 ### 4. Licence Field Tier Changes
 
-v2.1 reorganises how licence fields are structured across the three tiers. Two licence fields from v2.0 are gone, and three new BSI-specific terms replace them:
+v2.1 re-organises how licence fields are structured across the three tiers. Two licence fields from v2.0 are gone, and three new BSI-specific terms replace them:
 
 | v2.0 Field | v2.0 Tier | v2.1 Replacement | v2.1 Tier |
 |-----------|----------|-----------------|---------|
@@ -93,18 +91,18 @@ v2.1 reorganises how licence fields are structured across the three tiers. Two l
 | Declared licences | Optional | **Original licences** (renamed) | **Additional** |
 | — | — | **Effective licence** (new) | Optional |
 
-The key promotion: "Declared licences" was optional in v2.0. In v2.1, the same concept — renamed "Original licences" — is now **additional**, meaning it must be declared whenever the data exists.
+The key promotion: "Declared licences" was optional in v2.0. In v2.1, the same concept, renamed "Original licences", is now **additional**, meaning it must be declared whenever the data exists.
 
 "Concluded licences" (additional in v2.0) is removed from v2.1 entirely. Its role is absorbed into the BSI-defined "Distribution licences" concept.
 
-All other additional fields (SBOM-URI, Source code URI, URI of deployable form, Other unique identifiers) **remain additional** — their tier is unchanged.
+All other additional fields (SBOM-URI, Source code URI, URI of deployable form, Other unique identifiers) **remain additional**, their tier is unchanged.
 
 ### 5. New Optional Fields
 
 v2.1 adds two new optional fields that weren't in v2.0 at all:
 
-- **Effective licence** — the licence the SBOM creator actually uses the component under
-- **URL of security.txt** — points to the component creator's `security.txt` (RFC 9116)
+- **Effective licence**: the licence the SBOM creator actually uses the component under
+- **URL of security.txt**: points to the component creator's `security.txt` (RFC 9116)
 
 The third optional field, **hash value of source code**, was already optional in v2.0 and remains so in v2.1.
 
@@ -112,7 +110,7 @@ The third optional field, **hash value of source code**, was already optional in
 
 ### New Profile: `bsi-v2.1`
 
-sbomqs now has a dedicated `bsi-v2.1` profile. And importantly — the default `bsi` alias now points to `bsi-v2.1`. So if you've been running `--profile bsi`, you're already scoring against v2.1.
+sbomqs now has a dedicated `bsi-v2.1` profile. And importantly, the default `bsi` alias now points to `bsi-v2.1`. So if you've been running `--profile bsi`, you're already scoring against v2.1.
 
 All three BSI profiles are still available:
 
@@ -122,15 +120,15 @@ sbomqs score samples/sbom_cdx.json --profile bsi-v2.0
 sbomqs score samples/sbom_cdx.json --profile bsi-v2.1
 ```
 
-To compare your SBOM across all three BSI versions at once:
+To score your SBOM across all three BSI versions at once:
 
 ```bash
-sbomqs score samples/sbom_cdx.json --profile bsi-v1.1,bsi-v2.0,bsi-v2.1
+sbomqs score testdata/bsi/cdx/validFullyCompliantBsiV21.cdx16.json --profile bsi-v2.1
 ```
 
 This is useful to see exactly what additional fields are needed to move from v2.0 to v2.1 compliance.
 
-### Scoring Against BSI v2.1
+### Scoring against BSI v2.1
 
 ```bash
 sbomqs score samples/sbom_cdx.json --profile bsi-v2.1
@@ -139,10 +137,7 @@ sbomqs score samples/sbom_cdx.json --profile bsi-v2.1
 The output gives you a feature-by-feature scorecard:
 
 ```bash
-SBOM Quality Score: 3.2/10.0   Grade: F   Components: 38    EngineVersion: 5   File: samples/sbom_cdx.json
-
-
-SBOM Quality Score: 2.8/10.0	 Grade: F	Components: 392 	 EngineVersion: 6	File: ../sbomqs-syft-sbom.cdx.json
+SBOM Quality Score: 10.0/10.0	 Grade: A	Components: 2 	 EngineVersion: 6	File: testdata/bsi/cdx/validFullyCompliantBsiV21.cdx16.json
 
 
 +---------------------+---------------------------+------------------------+--------------------------------+
@@ -151,92 +146,97 @@ SBOM Quality Score: 2.8/10.0	 Grade: F	Components: 392 	 EngineVersion: 6	File: 
 | BSI TR-03183-2 v2.1 | sbom_spec_version         | 10.0/10.0              | CycloneDX 1.6 meets minimum    |
 |                     |                           |                        | version 1.6                    |
 +                     +---------------------------+------------------------+--------------------------------+
-|                     | sbom_creator              | 0.0/10.0               | SBOM creator is missing        |
+|                     | sbom_creator              | 10.0/10.0              | SBOM creator contact(email)    |
+|                     |                           |                        | provided via authors           |
 +                     +---------------------------+------------------------+--------------------------------+
 |                     | sbom_timestamp            | 10.0/10.0              | SBOM creation timestamp is     |
 |                     |                           |                        | valid and RFC3339-compliant.   |
 +                     +---------------------------+------------------------+--------------------------------+
-|                     | comp_creator              | 0.0/10.0               | creator information missing    |
-|                     |                           |                        | for all components             |
+|                     | comp_creator              | 10.0/10.0              | creator contact (email or URL) |
+|                     |                           |                        | declared for all components    |
 +                     +---------------------------+------------------------+--------------------------------+
 |                     | comp_name                 | 10.0/10.0              | component name declared for    |
 |                     |                           |                        | all components                 |
 +                     +---------------------------+------------------------+--------------------------------+
-|                     | comp_version              | 0.0/10.0               | component version missing for  |
-|                     |                           |                        | 19 out of 392 components       |
+|                     | comp_version              | 10.0/10.0              | component version declared for |
+|                     |                           |                        | all components                 |
 +                     +---------------------------+------------------------+--------------------------------+
-|                     | comp_filename             | 0.0/10.0               | no components declare filename |
+|                     | comp_filename             | 10.0/10.0              | filename declared for all      |
+|                     |                           |                        | components                     |
 +                     +---------------------------+------------------------+--------------------------------+
-|                     | comp_depth                | 0.0/10.0               | Primary component does not     |
-|                     |                           |                        | declare its dependencies.      |
+|                     | comp_depth                | 10.0/10.0              | Dependencies are recursively   |
+|                     |                           |                        | declared and structurally      |
+|                     |                           |                        | complete.                      |
 +                     +---------------------------+------------------------+--------------------------------+
-|                     | comp_distribution_license | 0.0/10.0               | no components declare          |
-|                     |                           |                        | distribution licence           |
-|                     |                           |                        | (concluded)                    |
+|                     | comp_distribution_license | 10.0/10.0              | distribution licence           |
+|                     |                           |                        | (concluded) declared for all   |
+|                     |                           |                        | components                     |
 +                     +---------------------------+------------------------+--------------------------------+
-|                     | comp_hash                 | 0.0/10.0               | no components declare          |
-|                     |                           |                        | deployable component hash      |
+|                     | comp_hash                 | 10.0/10.0              | deployable component hash      |
+|                     |                           |                        | declared for all components    |
 +                     +---------------------------+------------------------+--------------------------------+
-|                     | comp_executable_prop      | 0.0/10.0               | no components declare          |
-|                     |                           |                        | executable property            |
+|                     | comp_executable_prop      | 10.0/10.0              | executable property declared   |
+|                     |                           |                        | for all components             |
 +                     +---------------------------+------------------------+--------------------------------+
-|                     | comp_archive_prop         | 0.0/10.0               | no components declare archive  |
-|                     |                           |                        | property                       |
+|                     | comp_archive_prop         | 10.0/10.0              | archive property declared for  |
+|                     |                           |                        | all components                 |
 +                     +---------------------------+------------------------+--------------------------------+
-|                     | comp_structured_prop      | 0.0/10.0               | no components declare          |
-|                     |                           |                        | structured property            |
+|                     | comp_structured_prop      | 10.0/10.0              | structured property declared   |
+|                     |                           |                        | for all components             |
 +                     +---------------------------+------------------------+--------------------------------+
 |                     | sbom_uri                  | 10.0/10.0 (additional) | SBOM-URI is declared           |
 +                     +---------------------------+------------------------+--------------------------------+
-|                     | comp_source_code_url      | 0.0/10.0 (additional)  | no components declare source   |
-|                     |                           |                        | code URI                       |
+|                     | comp_source_code_url      | 10.0/10.0 (additional) | source code URI declared for   |
+|                     |                           |                        | all components                 |
 +                     +---------------------------+------------------------+--------------------------------+
-|                     | comp_download_url         | 0.0/10.0 (additional)  | no components declare          |
-|                     |                           |                        | deployable form URI            |
+|                     | comp_download_url         | 10.0/10.0 (additional) | deployable form URI declared   |
+|                     |                           |                        | for all components             |
 +                     +---------------------------+------------------------+--------------------------------+
-|                     | comp_other_identifiers    | 9.5/10.0 (additional)  | 373/392 components             |
-|                     |                           |                        | declare unique identifiers     |
-|                     |                           |                        | (CPE/SWID/purl)                |
+|                     | comp_other_identifiers    | 10.0/10.0 (additional) | unique identifiers             |
+|                     |                           |                        | (CPE/SWID/purl) declared for   |
+|                     |                           |                        | all components                 |
 +                     +---------------------------+------------------------+--------------------------------+
-|                     | comp_concluded_license    | 1.4/10.0 (additional)  | 56/392 components declare      |
-|                     |                           |                        | original licence (declared)    |
+|                     | comp_original_licenses    | 10.0/10.0 (additional) | original licence (declared)    |
+|                     |                           |                        | declared for all components    |
 +                     +---------------------------+------------------------+--------------------------------+
-|                     | comp_effective_license    | 0.0/10.0 (optional)    | no components declare          |
-|                     |                           |                        | effective licence              |
+|                     | comp_effective_license    | 10.0/10.0 (optional)   | effective licence declared for |
+|                     |                           |                        | all components                 |
 +                     +---------------------------+------------------------+--------------------------------+
-|                     | comp_source_hash          | 0.0/10.0 (optional)    | no components declare source   |
-|                     |                           |                        | code hash                      |
+|                     | comp_source_hash          | 10.0/10.0 (optional)   | source code hash declared for  |
+|                     |                           |                        | all components                 |
 +                     +---------------------------+------------------------+--------------------------------+
-|                     | comp_security_txt_url     | 0.0/10.0 (optional)    | no components declare          |
-|                     |                           |                        | security.txt URL               |
+|                     | comp_security_txt_url     | 10.0/10.0 (optional)   | security.txt URL declared for  |
+|                     |                           |                        | all components                 |
 +---------------------+---------------------------+------------------------+--------------------------------+
 
 
 Summary:
-Required Fields   : 3/13 compliant
-Additional Fields : 1/5 compliant
-Optional Fields   : 0/3 present
+Required Fields   : 13/13 compliant
+Additional Fields : 5/5 compliant
+Optional Fields   : 3/3 present
 
 Love to hear your feedback https://forms.gle/anFSspwrk7uSfD7Q6
 ```
 
-Each row tells you exactly which field is missing and for how many components — so you know precisely what to fix.
+Each row tells you exactly which field is missing and for how many components, so you know precisely what to fix.
 
-The summary at the bottom breaks it down into required, additional, and optional fields — matching the three tiers BSI v2.1 uses.
+The summary at the bottom breaks it down into required, additional, and optional fields, matching the three tiers BSI v2.1 uses.
 
-### Detailed Component-Level Check
+### Detailed Component-Level check
 
 Once you know the overall gaps, use the compliance command to drill down component by component:
 
 ```bash
-sbomqs compliance --bsi-v2.1 samples/sbom_cdx.json
+sbomqs compliance --bsi-v21 testdata/bsi/cdx/validFullyCompliantBsiV21.cdx16.json
 ```
 
-This gives you a full table showing the compliance status of each field for every single component — so you know exactly which components are missing which fields.
+This gives you a full table showing the compliance status of each field for every single component, so you know exactly which components are missing which fields.
 
 ### A Note on SPDX v2 SBOMs
 
 If you run an SPDX v2 SBOM against `bsi-v2.1`, sbomqs will return a hard fail on the format version check and mark all field checks as N/A. This is by design — BSI v2.1 does not accept SPDX v2. You need to either upgrade to SPDX 3.0.1 or use CycloneDX 1.6.
+
+BSI v2.1 requires SPDX 3.0.1 as the minimum, but sbomqs does not yet support SPDX 3.0.1. If you run an SPDX v2 SBOM against `bsi-v2.1`, sbomqs performs a best-effort check, it checks the fields that SPDX v2 does expose, and skips the ones it cannot map. There is no hard fail. For accurate SPDX v2 results, use `bsi-v1.1` (built for SPDX v2) or `bsi-v2.0` (very similar field set to v2.1, with SPDX v2 field mappings).
 
 ## Conclusion
 

--- a/content/posts/sbomqs-bsi-v2.1-compliance-support.md
+++ b/content/posts/sbomqs-bsi-v2.1-compliance-support.md
@@ -1,0 +1,258 @@
++++
+date = '2026-03-27T10:00:00+05:30'
+draft = false
+title = 'sbomqs Now Supports BSI TR-03183 v2.1: What Changed and How to Score Your SBOM'
+categories = ['Compliance', 'Quality', 'Tools']
+tags = ['SBOM', 'sbomqs', 'BSI', 'Compliance', 'CRA', 'Standards', 'Security', 'SBOM Quality']
+author = 'Vivek Sahu'
+description = 'sbomqs now supports BSI TR-03183-2 v2.1 compliance scoring. Learn what changed from v2.0, and how to score your SBOM against the latest BSI standard using sbomqs.'
++++
+
+Hey SBOM community,
+
+Good news — [sbomqs](https://github.com/interlynk-io/sbomqs) now supports **BSI TR-03183-2 v2.1** compliance scoring.
+
+If you've been following BSI compliance, you already know: BSI doesn't sit still. It has been one of the most consistently evolving SBOM compliance frameworks out there. Since its first publication in 2023, BSI has released a new version roughly every year — and each version has brought real, meaningful improvements to how SBOMs are expected to be structured.
+
+We already supported BSI v1.1 and BSI v2.0 in sbomqs. Now, with v2.1 being the most recent and the one that must be used for compliance, we've added full scoring support for it too.
+
+> If you want a deep dive into every BSI v2.1 field — what it means, what it maps to in SPDX and CycloneDX — check out our compliance series blog on BSI v2.1. This post focuses on what changed and how to use sbomqs to score your SBOM against it.
+
+## What is BSI TR-03183?
+
+**BSI TR-03183** is a Technical Guideline published by Germany's Federal Office for Information Security (Bundesamt für Sicherheit in der Informationstechnik). Part 2 focuses specifically on Software Bill of Materials (SBOM): what an SBOM must contain, how it should be structured, and which formats are acceptable.
+
+The reason BSI matters so much right now is the **EU Cyber Resilience Act (CRA)**. The CRA requires manufacturers of products with digital components to continuously handle vulnerabilities and provide transparent information about their products. BSI TR-03183 is closely aligned with CRA requirements, making it the go-to SBOM standard for organizations selling software products in the European market.
+
+> If you're selling software in Europe, BSI compliance is increasingly becoming a requirement — not a nice-to-have.
+
+## BSI Version History
+
+| Version | Date       | Key Changes                                                                 |
+| ------- | ---------- | --------------------------------------------------------------------------- |
+| 1.0     | 2023-07-12 | First publication                                                           |
+| 1.1     | 2023-11-28 | Translated to English; updated requirements for creator, version, licence  |
+| 2.0.0   | 2024-09-20 | Added new required fields (filename, executable, archive, structured); updated CycloneDX min to 1.5, SPDX min to 2.2.1 |
+| 2.1.0   | 2025-08-20 | Updated CycloneDX min to 1.6, SPDX min to 3.0.1; introduced logical and identified components; promoted several fields to required; added format field mapping tables |
+
+Each version has made the standard more complete and practical. And there's a clear rule: you must always use the most recent version for new SBOMs. The only exception is the immediately preceding version, which can be used for up to six months after a new version is published.
+
+So BSI v2.1 is now the required version. Let's look at what changed.
+
+## What Changed from BSI v2.0 to BSI v2.1?
+
+BSI v2.1 is not a ground-up rewrite. But there are several meaningful changes that affect both how you write your SBOM and how sbomqs scores it.
+
+### 1. Format Version Bumps — and SPDX v2 is No Longer Allowed
+
+| Format     | BSI v2.0 Minimum | BSI v2.1 Minimum |
+| ---------- | ---------------- | ---------------- |
+| CycloneDX  | 1.5              | **1.6**          |
+| SPDX       | 2.2.1            | **3.0.1**        |
+
+The SPDX change is the bigger one. BSI v2.1 requires SPDX 3.0.1 or higher — SPDX v2 is no longer accepted. In sbomqs, if you score an SPDX v2 SBOM against the `bsi-v2.1` profile, it gets a **hard fail** on the format version check and all individual field checks return N/A.
+
+### 2. New Component Concepts Introduced
+
+Before v2.1, BSI defined every component as a single executable or archive file. That left two situations unclear: how to represent an abstract product (like an application made of many files), and how to handle dependencies that sit *outside* your delivery boundary.
+
+v2.1 solves this by introducing two new component roles alongside the existing fully described component:
+
+**Logical Component**: An abstract representation of a product, framework, or application — not a physical file. For example: a PHP application running inside a container. Without a logical component, your SBOM is just a pile of files with no concept of "this is my app." A logical component names that unit and can carry a BOM reference pointing to its own SBOM. Because there is no physical file, it requires no filename, hash, or executable/archive/structured properties — just creator, name, version, dependencies, licence fields, unique identifiers, and URL of **security.txt**.
+
+**Identified Component**: A physical file that exists *outside* your scope of delivery — something your software depends on but you didn't ship. You don't need to fully describe it, just identify it so consumers can unambiguously chain SBOMs. Minimum fields: creator, name, version, and other unique identifiers (PURL or CPE).
+
+BSI v2.1 gives a clear priority order for deciding how much to record:
+
+```
+1. Referenced component  →  3 fields + pointer to another BOM
+2. Identified component  →  4 fields (at scope boundary)
+3. Fully described component  →  all fields (inside your delivery)
+```
+
+Before v2.1, there was no guidance on how to handle components at the boundary of your delivery. Now BSI explicitly tells you: identify them, don't fully describe them.
+
+### 3. Licence Terminology Clarified
+
+BSI v2.1 now explicitly defines three categories of licence information, using their own terms instead of SPDX/CycloneDX terminology:
+
+- **Original licences**: Licences assigned by the creator of the component. Maps to "declared licences" in SPDX/CycloneDX.
+- **Distribution licences**: Licences under which the component can be used by a licensee. Maps to "concluded licences" in SPDX/CycloneDX.
+- **Effective licence**: The licence under which this specific SBOM creator is using the component.
+
+The reason for this: the terms "declared" and "concluded" are used differently across SPDX and CycloneDX, creating confusion. BSI v2.1 sidesteps that by using its own precise terminology.
+
+### 4. Fields Promoted from Additional to Required
+
+This is a significant change. Several fields that were "additional" (must be present *if available*) in v2.0 are now **required** in v2.1:
+
+| Field | v2.0 Status | v2.1 Status |
+|-------|------------|-------------|
+| SBOM-URI | Additional | **Required** |
+| Source code URI | Additional | **Required** |
+| URI of deployable form | Additional | **Required** |
+| Other unique identifiers (PURL/CPE) | Additional | **Required** |
+| Original licences | Additional | **Required** |
+
+If your SBOM was passing v2.0 with these fields missing, it will now fail v2.1.
+
+### 5. New Optional Fields
+
+v2.1 also adds three new optional fields that weren't in v2.0 at all:
+
+- **Effective licence** — the licence the SBOM creator actually uses the component under
+- **Hash value of source code** — SHA-512 hash of the component's source
+- **URL of security.txt** — points to the component creator's `security.txt` (RFC 9116)
+
+## sbomqs v2.1 Support
+
+### New Profile: `bsi-v2.1`
+
+sbomqs now has a dedicated `bsi-v2.1` profile. And importantly — the default `bsi` alias now points to `bsi-v2.1`. So if you've been running `--profile bsi`, you're already scoring against v2.1.
+
+All three BSI profiles are still available:
+
+```bash
+sbomqs score samples/sbom_cdx.json --profile bsi-v1.1
+sbomqs score samples/sbom_cdx.json --profile bsi-v2.0
+sbomqs score samples/sbom_cdx.json --profile bsi-v2.1
+```
+
+To compare your SBOM across all three BSI versions at once:
+
+```bash
+sbomqs score samples/sbom_cdx.json --profile bsi-v1.1,bsi-v2.0,bsi-v2.1
+```
+
+This is useful to see exactly what additional fields are needed to move from v2.0 to v2.1 compliance.
+
+### Scoring Against BSI v2.1
+
+```bash
+sbomqs score samples/sbom_cdx.json --profile bsi-v2.1
+```
+
+The output gives you a feature-by-feature scorecard:
+
+```bash
+SBOM Quality Score: 3.2/10.0   Grade: F   Components: 38    EngineVersion: 5   File: samples/sbom_cdx.json
+
+
+SBOM Quality Score: 2.8/10.0	 Grade: F	Components: 392 	 EngineVersion: 6	File: ../sbomqs-syft-sbom.cdx.json
+
+
++---------------------+---------------------------+------------------------+--------------------------------+
+|       PROFILE       |          FEATURE          |         STATUS         |              DESC              |
++---------------------+---------------------------+------------------------+--------------------------------+
+| BSI TR-03183-2 v2.1 | sbom_spec_version         | 10.0/10.0              | CycloneDX 1.6 meets minimum    |
+|                     |                           |                        | version 1.6                    |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | sbom_creator              | 0.0/10.0               | SBOM creator is missing        |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | sbom_timestamp            | 10.0/10.0              | SBOM creation timestamp is     |
+|                     |                           |                        | valid and RFC3339-compliant.   |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_creator              | 0.0/10.0               | creator information missing    |
+|                     |                           |                        | for all components             |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_name                 | 10.0/10.0              | component name declared for    |
+|                     |                           |                        | all components                 |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_version              | 0.0/10.0               | component version missing for  |
+|                     |                           |                        | 19 out of 392 components       |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_filename             | 0.0/10.0               | no components declare filename |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_depth                | 0.0/10.0               | Primary component does not     |
+|                     |                           |                        | declare its dependencies.      |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_distribution_license | 0.0/10.0               | no components declare          |
+|                     |                           |                        | distribution licence           |
+|                     |                           |                        | (concluded)                    |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_hash                 | 0.0/10.0               | no components declare          |
+|                     |                           |                        | deployable component hash      |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_executable_prop      | 0.0/10.0               | no components declare          |
+|                     |                           |                        | executable property            |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_archive_prop         | 0.0/10.0               | no components declare archive  |
+|                     |                           |                        | property                       |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_structured_prop      | 0.0/10.0               | no components declare          |
+|                     |                           |                        | structured property            |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | sbom_uri                  | 10.0/10.0 (additional) | SBOM-URI is declared           |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_source_code_url      | 0.0/10.0 (additional)  | no components declare source   |
+|                     |                           |                        | code URI                       |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_download_url         | 0.0/10.0 (additional)  | no components declare          |
+|                     |                           |                        | deployable form URI            |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_other_identifiers    | 9.5/10.0 (additional)  | 373/392 components             |
+|                     |                           |                        | declare unique identifiers     |
+|                     |                           |                        | (CPE/SWID/purl)                |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_concluded_license    | 1.4/10.0 (additional)  | 56/392 components declare      |
+|                     |                           |                        | original licence (declared)    |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_effective_license    | 0.0/10.0 (optional)    | no components declare          |
+|                     |                           |                        | effective licence              |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_source_hash          | 0.0/10.0 (optional)    | no components declare source   |
+|                     |                           |                        | code hash                      |
++                     +---------------------------+------------------------+--------------------------------+
+|                     | comp_security_txt_url     | 0.0/10.0 (optional)    | no components declare          |
+|                     |                           |                        | security.txt URL               |
++---------------------+---------------------------+------------------------+--------------------------------+
+
+
+Summary:
+Required Fields   : 3/13 compliant
+Additional Fields : 1/5 compliant
+Optional Fields   : 0/3 present
+
+Love to hear your feedback https://forms.gle/anFSspwrk7uSfD7Q6
+```
+
+Each row tells you exactly which field is missing and for how many components — so you know precisely what to fix.
+
+The summary at the bottom breaks it down into required, additional, and optional fields — matching the three tiers BSI v2.1 uses.
+
+### Detailed Component-Level Check
+
+Once you know the overall gaps, use the compliance command to drill down component by component:
+
+```bash
+sbomqs compliance --bsi-v2.1 samples/sbom_cdx.json
+```
+
+This gives you a full table showing the compliance status of each field for every single component — so you know exactly which components are missing which fields.
+
+### A Note on SPDX v2 SBOMs
+
+If you run an SPDX v2 SBOM against `bsi-v2.1`, sbomqs will return a hard fail on the format version check and mark all field checks as N/A. This is by design — BSI v2.1 does not accept SPDX v2. You need to either upgrade to SPDX 3.0.1 or use CycloneDX 1.6.
+
+## Conclusion
+
+BSI v2.1 is a meaningful step forward from v2.0. The format bumps, the new component concepts, the promoted fields, and the clearer licence terminology all make the standard more precise and practical to implement.
+
+The fields themselves were largely in v2.0. But v2.1 makes more of them required, tightens the format requirements, and removes the ambiguity around how to handle components at the boundary of your delivery.
+
+With sbomqs, you don't need to manually check all of this. Just run a command, read the output, and you'll know exactly where your SBOM stands against BSI v2.1.
+
+If you love sbomqs, show your support by starring the [repository](https://github.com/interlynk-io/sbomqs/) ⭐.
+
+That's all for today. Keep learning and keep growing...
+
+Before signing off, if you'd like to see the complete analysis of your SBOM, try our community version of the Interlynk Platform. Visit [interlynk.io](https://www.interlynk.io/) and [sign up](https://app.interlynk.io/auth).
+
+## External Resources
+
+- [sbomqs](https://github.com/interlynk-io/sbomqs) GitHub repository
+- sbomqs compliance [readme](https://github.com/interlynk-io/sbomqs/blob/main/Compliance.md)
+- [BSI TR-03183-2 v2.1.0](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TR03183/BSI-TR-03183-2_v2_1_0.pdf) official document
+- [BSI TR-03183 overview](https://www.bsi.bund.de/dok/TR-03183-en) on BSI website
+- Previous post: [sbomqs Scoring Support for BSI 1.1 and BSI 2.0](/posts/sbomqs-scoring-support-for-bsi-1.1-and-bsi-2.0-in-a-summarized-way/)
+- Interlynk [community-tier](https://www.interlynk.io/community-tier)

--- a/content/posts/sbomqs-bsi-v2.1-compliance-support.md
+++ b/content/posts/sbomqs-bsi-v2.1-compliance-support.md
@@ -33,7 +33,7 @@ The reason BSI matters so much right now is the **EU Cyber Resilience Act (CRA)*
 | 1.0     | 2023-07-12 | First publication                                                           |
 | 1.1     | 2023-11-28 | Translated to English; updated requirements for creator, version, licence  |
 | 2.0.0   | 2024-09-20 | Added new required fields (filename, executable, archive, structured); updated CycloneDX min to 1.5, SPDX min to 2.2.1 |
-| 2.1.0   | 2025-08-20 | Updated CycloneDX min to 1.6, SPDX min to 3.0.1; introduced logical and identified components; promoted several fields to required; added format field mapping tables |
+| 2.1.0   | 2025-08-20 | Updated CycloneDX min to 1.6, SPDX min to 3.0.1; introduced logical and identified components; overhauled licence terminology; added format field mapping tables |
 
 Each version has made the standard more complete and practical. And there's a clear rule: you must always use the most recent version for new SBOMs. The only exception is the immediately preceding version, which can be used for up to six months after a new version is published.
 
@@ -82,27 +82,31 @@ BSI v2.1 now explicitly defines three categories of licence information, using t
 
 The reason for this: the terms "declared" and "concluded" are used differently across SPDX and CycloneDX, creating confusion. BSI v2.1 sidesteps that by using its own precise terminology.
 
-### 4. Fields Promoted from Additional to Required
+### 4. Licence Field Tier Changes
 
-This is a significant change. Several fields that were "additional" (must be present *if available*) in v2.0 are now **required** in v2.1:
+v2.1 reorganises how licence fields are structured across the three tiers. Two licence fields from v2.0 are gone, and three new BSI-specific terms replace them:
 
-| Field | v2.0 Status | v2.1 Status |
-|-------|------------|-------------|
-| SBOM-URI | Additional | **Required** |
-| Source code URI | Additional | **Required** |
-| URI of deployable form | Additional | **Required** |
-| Other unique identifiers (PURL/CPE) | Additional | **Required** |
-| Original licences | Additional | **Required** |
+| v2.0 Field | v2.0 Tier | v2.1 Replacement | v2.1 Tier |
+|-----------|----------|-----------------|---------|
+| Associated licences | Required | **Distribution licences** (renamed) | Required |
+| Concluded licences | Additional | — (removed) | — |
+| Declared licences | Optional | **Original licences** (renamed) | **Additional** |
+| — | — | **Effective licence** (new) | Optional |
 
-If your SBOM was passing v2.0 with these fields missing, it will now fail v2.1.
+The key promotion: "Declared licences" was optional in v2.0. In v2.1, the same concept — renamed "Original licences" — is now **additional**, meaning it must be declared whenever the data exists.
+
+"Concluded licences" (additional in v2.0) is removed from v2.1 entirely. Its role is absorbed into the BSI-defined "Distribution licences" concept.
+
+All other additional fields (SBOM-URI, Source code URI, URI of deployable form, Other unique identifiers) **remain additional** — their tier is unchanged.
 
 ### 5. New Optional Fields
 
-v2.1 also adds three new optional fields that weren't in v2.0 at all:
+v2.1 adds two new optional fields that weren't in v2.0 at all:
 
 - **Effective licence** — the licence the SBOM creator actually uses the component under
-- **Hash value of source code** — SHA-512 hash of the component's source
 - **URL of security.txt** — points to the component creator's `security.txt` (RFC 9116)
+
+The third optional field, **hash value of source code**, was already optional in v2.0 and remains so in v2.1.
 
 ## sbomqs v2.1 Support
 
@@ -238,7 +242,7 @@ If you run an SPDX v2 SBOM against `bsi-v2.1`, sbomqs will return a hard fail on
 
 BSI v2.1 is a meaningful step forward from v2.0. The format bumps, the new component concepts, the promoted fields, and the clearer licence terminology all make the standard more precise and practical to implement.
 
-The fields themselves were largely in v2.0. But v2.1 makes more of them required, tightens the format requirements, and removes the ambiguity around how to handle components at the boundary of your delivery.
+The fields themselves were largely in v2.0. But v2.1 tightens the format requirements, promotes "Declared licences" from optional to additional (renaming it "Original licences"), removes the ambiguity around how to handle components at the boundary of your delivery, and adds clearer licence terminology throughout.
 
 With sbomqs, you don't need to manually check all of this. Just run a command, read the output, and you'll know exactly where your SBOM stands against BSI v2.1.
 

--- a/content/posts/sbomqs-bsi-v2.1-compliance-support.md
+++ b/content/posts/sbomqs-bsi-v2.1-compliance-support.md
@@ -60,14 +60,6 @@ v2.1 solves this by introducing two new component roles alongside the existing f
 
 **Identified Component**: A physical file that exists *outside* your scope of delivery, something your software depends on but you didn't ship. You don't need to fully describe it, just identify it so consumers can unambiguously chain SBOMs. Minimum fields: creator, name, version, and other unique identifiers (PURL or CPE).
 
-BSI v2.1 gives a clear priority order for deciding how much to record:
-
-```text
-1. Referenced component: 3 fields + pointer to another BOM
-2. Identified component: 4 fields (at scope boundary)
-3. Fully described component: all fields (inside your delivery)
-```
-
 Before v2.1, there was no guidance on how to handle components at the boundary of your delivery. Now BSI explicitly tells you: identify them, don't fully describe them.
 
 ### 3. Licence Terminology Clarified


### PR DESCRIPTION
This PR adds the following changes:
- adds compliance series part 5 on bsi:v2.1 blog
- add sbomqs supporting bsi:v2.1 compliance blog